### PR TITLE
Fix deb packaging path after openjdk 21 update

### DIFF
--- a/build/package-deb.sh
+++ b/build/package-deb.sh
@@ -18,7 +18,7 @@ jpackage --input ./input/ --name OwlPlug --main-class org.springframework.boot.l
 --linux-package-name owlplug --linux-deb-maintainer contact@owlplug.com \
 --linux-menu-group "AudioVideo;Audio" --linux-shortcut
 
-mv ./output/owlplug_$owlplugversion-1_amd64.deb ./output/OwlPlug-$owlplugversion.deb
+mv ./output/owlplug_${owlplugversion}_amd64.deb ./output/OwlPlug-$owlplugversion.deb
 
 ls ./output
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated the Debian package naming convention for improved clarity and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->