### PR TITLE
Fixed the following:

### DIFF
--- a/owlplug-client/src/main/java/com/owlplug/auth/dao/GoogleCredentialDAO.java
+++ b/owlplug-client/src/main/java/com/owlplug/auth/dao/GoogleCredentialDAO.java
@@ -19,11 +19,12 @@
 package com.owlplug.auth.dao;
 
 import com.owlplug.auth.model.GoogleCredential;
-import java.util.Set;
-import java.util.stream.Stream;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.CrudRepository;
 import org.springframework.stereotype.Repository;
+
+import java.util.Set;
+import java.util.stream.Stream;
 
 @Repository
 public interface GoogleCredentialDAO extends CrudRepository<GoogleCredential, Long> {
@@ -32,7 +33,7 @@ public interface GoogleCredentialDAO extends CrudRepository<GoogleCredential, Lo
 
   GoogleCredential findByAccessToken(String key);
 
-  @Query(value = "select key from GOOGLE_CREDENTIAL", nativeQuery = true)
+  @Query(value = "select credential_key from GOOGLE_CREDENTIAL", nativeQuery = true)
   Set<String> findAllKeys();
 
   @Query("select c from GoogleCredential c")

--- a/owlplug-client/src/main/java/com/owlplug/auth/model/GoogleCredential.java
+++ b/owlplug-client/src/main/java/com/owlplug/auth/model/GoogleCredential.java
@@ -19,14 +19,11 @@
 package com.owlplug.auth.model;
 
 import com.google.api.client.auth.oauth2.StoredCredential;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import java.time.Instant;
+import jakarta.persistence.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
+
+import java.time.Instant;
 
 /**
  * Owlplug JPA entity to handle google credentials.
@@ -38,7 +35,7 @@ public class GoogleCredential {
   @Id
   @GeneratedValue(strategy = GenerationType.AUTO)
   private Long id;
-  @Column(unique = true)
+  @Column(unique = true, name = "credential_key")
   private String key;
   private String accessToken;
   private Long expirationTimeMilliseconds;

--- a/owlplug-client/src/test/java/com/owlplug/dao/GoogleCredentialDAOTest.java
+++ b/owlplug-client/src/test/java/com/owlplug/dao/GoogleCredentialDAOTest.java
@@ -18,21 +18,23 @@
  
 package com.owlplug.dao;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import com.owlplug.auth.dao.GoogleCredentialDAO;
 import com.owlplug.auth.model.GoogleCredential;
+import java.util.Set;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
-
-import java.util.Set;
-import java.util.stream.Stream;
-
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.*;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @DataJpaTest
 public class GoogleCredentialDAOTest {

--- a/owlplug-client/src/test/java/com/owlplug/dao/GoogleCredentialDAOTest.java
+++ b/owlplug-client/src/test/java/com/owlplug/dao/GoogleCredentialDAOTest.java
@@ -18,23 +18,21 @@
  
 package com.owlplug.dao;
 
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.hasProperty;
-import static org.hamcrest.Matchers.is;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
 import com.owlplug.auth.dao.GoogleCredentialDAO;
 import com.owlplug.auth.model.GoogleCredential;
-import java.util.Set;
-import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.boot.test.autoconfigure.orm.jpa.TestEntityManager;
+
+import java.util.Set;
+import java.util.stream.Stream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 @DataJpaTest
 public class GoogleCredentialDAOTest {
@@ -45,7 +43,7 @@ public class GoogleCredentialDAOTest {
   @Autowired
   private GoogleCredentialDAO googleCredentialDAO;
 
-  @BeforeAll
+  @BeforeEach
   public void beforeTest() {
     GoogleCredential gc = new GoogleCredential();
     gc.setKey("TEST-KEY-1");


### PR DESCRIPTION
- Changed @BeforeAll to @BeforeEach in non-static method that cannot be static in GoogleCredentialDAOTest
- Changed GoogleCredential key column name to credential_key since key is a special key word
- Changed NativeQuery in GoogleCredentialDAO according to the new column name