### PR TITLE
Dev

### DIFF
--- a/owlplug-client/src/main/java/com/owlplug/auth/dao/GoogleCredentialDAO.java
+++ b/owlplug-client/src/main/java/com/owlplug/auth/dao/GoogleCredentialDAO.java
@@ -32,7 +32,7 @@ public interface GoogleCredentialDAO extends CrudRepository<GoogleCredential, Lo
 
   GoogleCredential findByAccessToken(String key);
 
-  @Query(value = "select key from GOOGLE_CREDENTIAL", nativeQuery = true)
+  @Query(value = "select credential_key from GOOGLE_CREDENTIAL", nativeQuery = true)
   Set<String> findAllKeys();
 
   @Query("select c from GoogleCredential c")

--- a/owlplug-client/src/main/java/com/owlplug/auth/model/GoogleCredential.java
+++ b/owlplug-client/src/main/java/com/owlplug/auth/model/GoogleCredential.java
@@ -38,7 +38,7 @@ public class GoogleCredential {
   @Id
   @GeneratedValue(strategy = GenerationType.AUTO)
   private Long id;
-  @Column(unique = true)
+  @Column(unique = true, name = "credential_key")
   private String key;
   private String accessToken;
   private Long expirationTimeMilliseconds;

--- a/owlplug-client/src/test/java/com/owlplug/dao/GoogleCredentialDAOTest.java
+++ b/owlplug-client/src/test/java/com/owlplug/dao/GoogleCredentialDAOTest.java
@@ -30,7 +30,7 @@ import com.owlplug.auth.dao.GoogleCredentialDAO;
 import com.owlplug.auth.model.GoogleCredential;
 import java.util.Set;
 import java.util.stream.Stream;
-import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
@@ -45,7 +45,7 @@ public class GoogleCredentialDAOTest {
   @Autowired
   private GoogleCredentialDAO googleCredentialDAO;
 
-  @BeforeAll
+  @BeforeEach
   public void beforeTest() {
     GoogleCredential gc = new GoogleCredential();
     gc.setKey("TEST-KEY-1");

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.owlplug</groupId>
 	<artifactId>owlplug</artifactId>
-	<version>1.26.0</version>
+	<version>1.26.1-SNAPSHOT</version>
 	<packaging>pom</packaging>
 
 


### PR DESCRIPTION
I found out that there is a breaking test in the `GoogleCredentialDAOTest` class regarding a `@BeforeAll` annotation being used in a `non-static` method. Turning it into a static make the access to `EntityManager` problematic, since it is not a big unit test, by turning it into a `BeforeEach` should be fine.

Also the `key` column name should be avoided because `key` is a special keyword in the database, therefore I changed the column name from `key` to `credential_key` in the `GoogleCredential` entity and updated the `GoogleCredentialDAO` repo accordingly in the _native query_.

Now all tests are passing smoothly.