### PR TITLE
take alias files into account by ignoring them

### DIFF
--- a/owlplug-client/src/main/java/com/owlplug/plugin/tasks/FileSyncTask.java
+++ b/owlplug-client/src/main/java/com/owlplug/plugin/tasks/FileSyncTask.java
@@ -107,9 +107,10 @@ public class FileSyncTask extends AbstractTask {
         directoryStat.getChilds().add(fileStat);
         length += fileStat.getLength();
 
-      } else {
+      } else if (file.isDirectory()) {
         length += extractFolderSize(file, directoryStat);
       }
+      // else it's probably a mac finder alias. Ignore it.
     }
 
     directoryStat.setLength(length);


### PR DESCRIPTION
See issue #357

I'm not very familiar with java but from what I found, it does not play nice with mac finder Alias files. I figure it's best to ignore them.