### PR TITLE
fixes #453: open Bowser with xdg-open if the desktop action is not supported

### DIFF
--- a/owlplug-client/src/main/java/com/owlplug/core/utils/PlatformUtils.java
+++ b/owlplug-client/src/main/java/com/owlplug/core/utils/PlatformUtils.java
@@ -19,6 +19,7 @@
 package com.owlplug.core.utils;
 
 import java.awt.Desktop;
+import java.awt.Desktop.Action;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -54,7 +55,12 @@ public class PlatformUtils {
     try {
       if (Desktop.isDesktopSupported()) {
         log.debug("Opening address " + url + " in default browser");
-        Desktop.getDesktop().browse(new URI(url));
+        Desktop desktop = Desktop.getDesktop();
+        if(desktop.isSupported(Action.BROWSE)) {
+          desktop.browse(new URI(url));
+        } else {
+          new ProcessBuilder("xdg-open", url).start();
+        }
       }
     } catch (IOException e) {
       log.error("Can't open default browser");

--- a/owlplug-client/src/main/java/com/owlplug/core/utils/PlatformUtils.java
+++ b/owlplug-client/src/main/java/com/owlplug/core/utils/PlatformUtils.java
@@ -53,14 +53,12 @@ public class PlatformUtils {
   public static void openDefaultBrowser(String url) {
 
     try {
-      if (Desktop.isDesktopSupported()) {
-        log.debug("Opening address " + url + " in default browser");
-        Desktop desktop = Desktop.getDesktop();
-        if(desktop.isSupported(Action.BROWSE)) {
-          desktop.browse(new URI(url));
-        } else {
-          new ProcessBuilder("xdg-open", url).start();
-        }
+      log.debug("Opening address " + url + " in default browser");
+      if (Desktop.isDesktopSupported() && Desktop.getDesktop().isSupported(Action.BROWSE)) {
+        Desktop.getDesktop().browse(new URI(url));
+      }
+      else {
+        new ProcessBuilder("xdg-open", url).start();
       }
     } catch (IOException e) {
       log.error("Can't open default browser");


### PR DESCRIPTION
Resoves #453.

That might resolve issue #330.

On some Linux distibutions/configurations the default browser in `java.awt.Desktop` is not Supported and throws an `java.lang.UnsupportedOperationException`.

The solution is to check whether the “Browse” action is available and then call `xdg-open`. `xdg-open` should be available in cases where the action is not supported.
