### PR TITLE
Configure loader timeout and fix plugin component display

### DIFF
--- a/owlplug-client/pom.xml
+++ b/owlplug-client/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<groupId>com.owlplug</groupId>
 		<artifactId>owlplug</artifactId>
-		<version>1.33.0</version>
+		<version>1.33.1</version>
 	</parent>
 
 	<artifactId>owlplug-client</artifactId>
@@ -35,17 +35,17 @@
 		<dependency>
 			<groupId>com.owlplug</groupId>
 			<artifactId>owlplug-host</artifactId>
-			<version>1.33.0</version>
+			<version>1.33.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.owlplug</groupId>
 			<artifactId>owlplug-controls</artifactId>
-			<version>1.33.0</version>
+			<version>1.33.1</version>
 		</dependency>
 		<dependency>
 			<groupId>com.owlplug</groupId>
 			<artifactId>owlplug-parsers</artifactId>
-			<version>1.33.0</version>
+			<version>1.33.1</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>

--- a/owlplug-client/src/main/java/com/owlplug/core/components/ApplicationDefaults.java
+++ b/owlplug-client/src/main/java/com/owlplug/core/components/ApplicationDefaults.java
@@ -108,6 +108,7 @@ public class ApplicationDefaults {
   public static final String LV2_EXTRA_DIRECTORY_KEY = "LV2_EXTRA_DIRECTORY_KEY";
   public static final String NATIVE_HOST_ENABLED_KEY = "NATIVE_HOST_ENABLED_KEY";
   public static final String PREFERRED_NATIVE_LOADER = "PREFERRED_NATIVE_LOADER";
+  public static final String NATIVE_LOADER_TIMEOUT_KEY = "NATIVE_LOADER_TIMEOUT_KEY";
   public static final String SELECTED_ACCOUNT_KEY = "SELECTED_ACCOUNT_KEY";
   public static final String SYNC_PLUGINS_STARTUP_KEY = "SYNC_PLUGINS_STARTUP_KEY";
   public static final String STORE_DIRECTORY_ENABLED_KEY = "STORE_DIRECTORY_ENABLED_KEY";

--- a/owlplug-client/src/main/java/com/owlplug/core/controllers/OptionsController.java
+++ b/owlplug-client/src/main/java/com/owlplug/core/controllers/OptionsController.java
@@ -63,6 +63,8 @@ public class OptionsController extends BaseController {
   @FXML
   private ComboBox<NativePluginLoader> pluginNativeComboBox;
   @FXML
+  private TextField loaderTimeoutTextField;
+  @FXML
   private CheckBox syncPluginsCheckBox;
   @FXML
   private CheckBox syncFileStatCheckbox;
@@ -155,6 +157,7 @@ public class OptionsController extends BaseController {
     pluginNativeCheckbox.selectedProperty().addListener((observable, oldValue, newValue) -> {
       this.getPreferences().putBoolean(ApplicationDefaults.NATIVE_HOST_ENABLED_KEY, newValue);
       this.pluginNativeComboBox.setDisable(!newValue);
+      updateScannerTimeoutFieldState();
     });
 
     ObservableList<NativePluginLoader> pluginLoaders = FXCollections.observableArrayList(
@@ -163,8 +166,25 @@ public class OptionsController extends BaseController {
 
     pluginNativeComboBox.getSelectionModel().selectedItemProperty().addListener((observable, oldValue, newValue) -> {
       if (newValue != null) {
-        this.getPreferences().put(ApplicationDefaults.PREFERRED_NATIVE_LOADER,newValue.getId());
+        this.getPreferences().put(ApplicationDefaults.PREFERRED_NATIVE_LOADER, newValue.getId());
         nativeHostService.setCurrentPluginLoader(newValue);
+        updateScannerTimeoutFieldState();
+      }
+    });
+
+    loaderTimeoutTextField.textProperty().addListener((observable, oldValue, newValue) -> {
+      if (!newValue.matches("\\d*")) {
+        loaderTimeoutTextField.setText(newValue.replaceAll("[^\\d]", ""));
+        return;
+      }
+      try {
+        long timeout = Long.parseLong(newValue);
+        if (timeout >= 0) {
+          this.getPreferences().putLong(ApplicationDefaults.NATIVE_LOADER_TIMEOUT_KEY, timeout);
+          nativeHostService.setScannerTimeout(timeout);
+        }
+      } catch (NumberFormatException ignored) {
+        // ignore invalid input
       }
     });
 
@@ -265,6 +285,13 @@ public class OptionsController extends BaseController {
     refreshView();
   }
 
+  private void updateScannerTimeoutFieldState() {
+    NativePluginLoader selected = pluginNativeComboBox.getSelectionModel().getSelectedItem();
+    boolean isOwlPlugScanner = selected != null && "owlplug-scanner".equals(selected.getId());
+    boolean nativeEnabled = pluginNativeCheckbox.isSelected() && !pluginNativeCheckbox.isDisable();
+    loaderTimeoutTextField.setDisable(!nativeEnabled || !isOwlPlugScanner);
+  }
+
   public void refreshView() {
 
     vst2PluginPathFragment.refresh();
@@ -286,6 +313,10 @@ public class OptionsController extends BaseController {
 
     NativePluginLoader pluginLoader = nativeHostService.getCurrentPluginLoader();
     pluginNativeComboBox.getSelectionModel().select(pluginLoader);
+
+    long timeout = this.getPreferences().getLong(ApplicationDefaults.NATIVE_LOADER_TIMEOUT_KEY, 30L);
+    loaderTimeoutTextField.setText(String.valueOf(timeout));
+    updateScannerTimeoutFieldState();
 
     if (!storeDirectoryCheckBox.isSelected()) {
       storeDirectoryTextField.setVisible(false);

--- a/owlplug-client/src/main/java/com/owlplug/core/controllers/OptionsController.java
+++ b/owlplug-client/src/main/java/com/owlplug/core/controllers/OptionsController.java
@@ -179,12 +179,14 @@ public class OptionsController extends BaseController {
       }
       try {
         long timeout = Long.parseLong(newValue);
-        if (timeout >= 0) {
+        if (timeout >= 0 && timeout <= 3600) {
           this.getPreferences().putLong(ApplicationDefaults.NATIVE_LOADER_TIMEOUT_KEY, timeout);
           nativeHostService.setScannerTimeout(timeout);
+        } else {
+          loaderTimeoutTextField.setText(oldValue);
         }
       } catch (NumberFormatException ignored) {
-        // ignore invalid input
+        // Ignore in case of invalid values (empty string)
       }
     });
 
@@ -314,7 +316,7 @@ public class OptionsController extends BaseController {
     NativePluginLoader pluginLoader = nativeHostService.getCurrentPluginLoader();
     pluginNativeComboBox.getSelectionModel().select(pluginLoader);
 
-    long timeout = this.getPreferences().getLong(ApplicationDefaults.NATIVE_LOADER_TIMEOUT_KEY, 30L);
+    long timeout = this.getPreferences().getLong(ApplicationDefaults.NATIVE_LOADER_TIMEOUT_KEY, 10L);
     loaderTimeoutTextField.setText(String.valueOf(timeout));
     updateScannerTimeoutFieldState();
 

--- a/owlplug-client/src/main/java/com/owlplug/core/services/OptionsService.java
+++ b/owlplug-client/src/main/java/com/owlplug/core/services/OptionsService.java
@@ -89,6 +89,9 @@ public class OptionsService extends BaseService {
     if (prefs.get(ApplicationDefaults.STORE_SUBDIRECTORY_ENABLED, null) == null) {
       prefs.putBoolean(ApplicationDefaults.STORE_SUBDIRECTORY_ENABLED, Boolean.TRUE);
     }
+    if (prefs.get(ApplicationDefaults.NATIVE_LOADER_TIMEOUT_KEY, null) == null) {
+      prefs.putLong(ApplicationDefaults.NATIVE_LOADER_TIMEOUT_KEY, 10L);
+    }
   }
 
   /**

--- a/owlplug-client/src/main/java/com/owlplug/plugin/controllers/PluginInfoController.java
+++ b/owlplug-client/src/main/java/com/owlplug/plugin/controllers/PluginInfoController.java
@@ -43,7 +43,6 @@ import java.util.Optional;
 import javafx.beans.property.ObjectProperty;
 import javafx.beans.property.SimpleObjectProperty;
 import javafx.collections.FXCollections;
-import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
 import javafx.scene.control.Button;
 import javafx.scene.control.Label;
@@ -111,6 +110,8 @@ public class PluginInfoController extends BaseController {
   private ListView<PluginComponent> pluginComponentListView;
   @FXML
   private ToggleSwitch nativeDiscoveryToggleButton;
+  @FXML
+  private Label lastScanErrorLabel;
 
   private final ObjectProperty<Plugin> pluginProperty = new SimpleObjectProperty<Plugin>();
   private final ArrayList<String> knownPluginImages = new ArrayList<>();
@@ -157,6 +158,8 @@ public class PluginInfoController extends BaseController {
     });
 
     pluginComponentListView.setCellFactory(new PluginComponentCellFactory(this.getApplicationDefaults()));
+    lastScanErrorLabel.managedProperty().bind(lastScanErrorLabel.visibleProperty());
+    lastScanErrorLabel.setVisible(false);
 
     nativeDiscoveryToggleButton.selectedProperty().addListener((observable, oldValue, newValue) -> {
       Plugin plugin = pluginProperty.get();
@@ -175,8 +178,6 @@ public class PluginInfoController extends BaseController {
       return;
     }
 
-    // All reads below come from already-loaded in-memory fields — safe to run
-    // on the FX thread without risk of blocking.
     pluginFormatIcon.setImage(this.getApplicationDefaults().getPluginFormatIcon(plugin.getFormat()));
     pluginFormatLabel.setText(plugin.getFormat().getText() + " Plugin");
     pluginTitleLabel.setText(plugin.getName());
@@ -202,6 +203,9 @@ public class PluginInfoController extends BaseController {
 
     if (plugin.getFootprint() != null) {
       nativeDiscoveryToggleButton.setSelected(plugin.getFootprint().isNativeDiscoveryEnabled());
+      String scanError = plugin.getFootprint().getLastScanStatus();
+      lastScanErrorLabel.setText(scanError != null ? scanError : "");
+      lastScanErrorLabel.setVisible(scanError != null);
     }
 
     setPluginImage();

--- a/owlplug-client/src/main/java/com/owlplug/plugin/controllers/PluginInfoController.java
+++ b/owlplug-client/src/main/java/com/owlplug/plugin/controllers/PluginInfoController.java
@@ -206,6 +206,8 @@ public class PluginInfoController extends BaseController {
       String scanError = plugin.getFootprint().getLastScanStatus();
       lastScanErrorLabel.setText(scanError != null ? scanError : "");
       lastScanErrorLabel.setVisible(scanError != null);
+    } else {
+      lastScanErrorLabel.setVisible(false);
     }
 
     setPluginImage();

--- a/owlplug-client/src/main/java/com/owlplug/plugin/controllers/PluginTableController.java
+++ b/owlplug-client/src/main/java/com/owlplug/plugin/controllers/PluginTableController.java
@@ -23,6 +23,7 @@ import com.owlplug.core.controllers.BaseController;
 import com.owlplug.core.utils.FileUtils;
 import com.owlplug.core.utils.PlatformUtils;
 import com.owlplug.plugin.controllers.dialogs.DisablePluginDialogController;
+import com.owlplug.plugin.model.IPlugin;
 import com.owlplug.plugin.model.Plugin;
 import com.owlplug.plugin.model.PluginFormat;
 import com.owlplug.plugin.model.PluginState;
@@ -63,9 +64,9 @@ public class PluginTableController extends BaseController {
   private PluginService pluginService;
 
   private final SimpleStringProperty search = new SimpleStringProperty();
-  private final TableView<Plugin> tableView;
+  private final TableView<IPlugin> tableView;
 
-  private final ObservableList<Plugin> pluginList;
+  private final ObservableList<IPlugin> pluginList;
 
 
   public PluginTableController() {
@@ -75,7 +76,7 @@ public class PluginTableController extends BaseController {
     createColumns();
 
     tableView.setRowFactory(tv -> {
-      TableRow<Plugin> row = new TableRow<>();
+      TableRow<IPlugin> row = new TableRow<>();
       row.itemProperty().addListener((obs, oldItem, newItem) -> {
         if (newItem != null) {
           row.setContextMenu(createPluginContextMenu(newItem));
@@ -88,7 +89,7 @@ public class PluginTableController extends BaseController {
     pluginList = FXCollections.observableArrayList();
     // Wraps an ObservableList and filters its content using the provided Predicate.
     // All changes in the ObservableList are propagated immediately to the FilteredList.
-    FilteredList<Plugin> filteredPluginList = new FilteredList<>(pluginList);
+    FilteredList<IPlugin> filteredPluginList = new FilteredList<>(pluginList);
 
     filteredPluginList.predicateProperty().bind(Bindings.createObjectBinding(() -> {
       if (search.getValue() == null || search.getValue().isEmpty()) {
@@ -99,17 +100,17 @@ public class PluginTableController extends BaseController {
                      search.getValue().toLowerCase()));
     }, search));
 
-    SortedList<Plugin> sortedPluginList = new SortedList<>(filteredPluginList);
+    SortedList<IPlugin> sortedPluginList = new SortedList<>(filteredPluginList);
     tableView.setItems(sortedPluginList);
     sortedPluginList.comparatorProperty().bind(tableView.comparatorProperty());
 
   }
 
   private void createColumns() {
-    TableColumn<Plugin, String> nameColumn = new TableColumn<>("Name");
+    TableColumn<IPlugin, String> nameColumn = new TableColumn<>("Name");
     nameColumn.setCellValueFactory(cellData -> new SimpleStringProperty(cellData.getValue().getName()));
-    TableColumn<Plugin, PluginFormat> formatColumn = new TableColumn<>("Format");
-    formatColumn.setCellValueFactory(cellData -> new SimpleObjectProperty<>(cellData.getValue().getFormat()));
+    TableColumn<IPlugin, PluginFormat> formatColumn = new TableColumn<>("Format");
+    formatColumn.setCellValueFactory(cellData -> new SimpleObjectProperty<>(cellData.getValue().asPlugin().getFormat()));
     formatColumn.setCellFactory(e -> new TableCell<>() {
       @Override
       public void updateItem(PluginFormat item, boolean empty) {
@@ -123,17 +124,17 @@ public class PluginTableController extends BaseController {
         }
       }
     });
-    TableColumn<Plugin, String> manufacturerColumn = new TableColumn<>("Manufacturer");
+    TableColumn<IPlugin, String> manufacturerColumn = new TableColumn<>("Manufacturer");
     manufacturerColumn.setCellValueFactory(cellData ->
                                                new SimpleStringProperty(cellData.getValue().getManufacturerName()));
-    TableColumn<Plugin, String> versionColumn = new TableColumn<>("Version");
+    TableColumn<IPlugin, String> versionColumn = new TableColumn<>("Version");
     versionColumn.setCellValueFactory(cellData -> new SimpleStringProperty(cellData.getValue().getVersion()));
-    TableColumn<Plugin, String> categoryColumn = new TableColumn<>("Category");
+    TableColumn<IPlugin, String> categoryColumn = new TableColumn<>("Category");
     categoryColumn.setCellValueFactory(cellData -> new SimpleStringProperty(cellData.getValue().getCategory()));
     // Directory Column
-    TableColumn<Plugin, String> directoryColumn = new TableColumn<>("Directory");
+    TableColumn<IPlugin, String> directoryColumn = new TableColumn<>("Directory");
     directoryColumn.setCellValueFactory(cellData -> new SimpleStringProperty(
-        FileUtils.getParentDirectoryName(cellData.getValue().getPath())));
+        FileUtils.getParentDirectoryName(cellData.getValue().asPlugin().getPath())));
     directoryColumn.setCellFactory(e -> new TableCell<>() {
       @Override
       public void updateItem(String item, boolean empty) {
@@ -148,9 +149,9 @@ public class PluginTableController extends BaseController {
       }
     });
     // Scan Directory Column
-    TableColumn<Plugin, String> scanDirectoryColumn = new TableColumn<>("Scan Dir.");
+    TableColumn<IPlugin, String> scanDirectoryColumn = new TableColumn<>("Scan Dir.");
     scanDirectoryColumn.setCellValueFactory(cellData -> new SimpleStringProperty(
-        FileUtils.getFilename(cellData.getValue().getScanDirectoryPath())));
+        FileUtils.getFilename(cellData.getValue().asPlugin().getScanDirectoryPath())));
     scanDirectoryColumn.setCellFactory(e -> new TableCell<>() {
       @Override
       public void updateItem(String item, boolean empty) {
@@ -165,9 +166,9 @@ public class PluginTableController extends BaseController {
       }
     });
     // Plugin State Column
-    TableColumn<Plugin, PluginState> stateColumn = new TableColumn<>("State");
+    TableColumn<IPlugin, PluginState> stateColumn = new TableColumn<>("State");
     stateColumn.setCellValueFactory(cellData -> new SimpleObjectProperty<>(
-        pluginService.getPluginState(cellData.getValue())));
+        pluginService.getPluginState(cellData.getValue().asPlugin())));
     stateColumn.setCellFactory(e -> new TableCell<>() {
       @Override
       public void updateItem(PluginState item, boolean empty) {
@@ -188,10 +189,16 @@ public class PluginTableController extends BaseController {
 
   public void setPlugins(Iterable<Plugin> plugins) {
     pluginList.clear();
-    plugins.forEach(pluginList::add);
+    plugins.forEach(p -> {
+      pluginList.add(p);
+      if (p.getComponents().size() > 1) {
+        pluginList.addAll(p.getComponents());
+      }
+    });
+
   }
 
-  public TableView<Plugin> getTableView() {
+  public TableView<IPlugin> getTableView() {
     return tableView;
   }
 
@@ -201,7 +208,8 @@ public class PluginTableController extends BaseController {
   }
 
   public void selectPluginById(long id) {
-    for (Plugin plugin : pluginList) {
+    for (IPlugin p : pluginList) {
+      Plugin plugin = p.asPlugin(); // Get plugin or component parent
       if (plugin.getId().equals(id)) {
         tableView.getSelectionModel().select(plugin);
         break;
@@ -217,37 +225,39 @@ public class PluginTableController extends BaseController {
     tableView.refresh();
   }
 
-  private ContextMenu createPluginContextMenu(Plugin plugin) {
+  private ContextMenu createPluginContextMenu(IPlugin plugin) {
 
     ContextMenu menu = new ContextMenu();
     MenuItem openDirItem = new MenuItem("Reveal in File Explorer");
     openDirItem.setOnAction(e -> {
-      File pluginFile = new File(plugin.getPath());
+      File pluginFile = new File(plugin.asPlugin().getPath());
       PlatformUtils.openFromDesktop(pluginFile.getParentFile());
     });
 
     menu.getItems().addAll(openDirItem, new SeparatorMenuItem());
 
-    if (plugin.isDisabled()) {
-      MenuItem enableItem = new MenuItem("Enable plugin");
-      enableItem.setOnAction(e -> {
-        Async.run(() -> pluginService.enablePlugin(plugin));
-      });
-      menu.getItems().add(enableItem);
-    } else {
-      MenuItem disableItem = new MenuItem("Disable plugin");
-      disableItem.setOnAction(e -> {
-        if (this.getPreferences().getBoolean(ApplicationDefaults.SHOW_DIALOG_DISABLE_PLUGIN_KEY, true)) {
-          this.disableController.setPlugin(plugin);
-          this.disableController.show();
-        } else {
-          this.disableController.disablePluginWithoutPrompt(plugin);
-        }
-      });
-      menu.getItems().add(disableItem);
-    }
+    if (plugin instanceof Plugin p) {
+      if (p.isDisabled()) {
+        MenuItem enableItem = new MenuItem("Enable plugin");
+        enableItem.setOnAction(e -> {
+          Async.run(() -> pluginService.enablePlugin(p));
+        });
+        menu.getItems().add(enableItem);
+      } else {
+        MenuItem disableItem = new MenuItem("Disable plugin");
+        disableItem.setOnAction(e -> {
+          if (this.getPreferences().getBoolean(ApplicationDefaults.SHOW_DIALOG_DISABLE_PLUGIN_KEY, true)) {
+            this.disableController.setPlugin(p);
+            this.disableController.show();
+          } else {
+            this.disableController.disablePluginWithoutPrompt(p);
+          }
+        });
+        menu.getItems().add(disableItem);
+      }
 
-    menu.getItems().add(new SeparatorMenuItem());
+      menu.getItems().add(new SeparatorMenuItem());
+    }
 
     MenuItem infoDisplayItem = new MenuItem("Toggle info display");
     menu.getItems().add(infoDisplayItem);

--- a/owlplug-client/src/main/java/com/owlplug/plugin/controllers/PluginTreeViewController.java
+++ b/owlplug-client/src/main/java/com/owlplug/plugin/controllers/PluginTreeViewController.java
@@ -21,6 +21,7 @@ package com.owlplug.plugin.controllers;
 import com.owlplug.core.controllers.BaseController;
 import com.owlplug.core.ui.FilterableTreeItem;
 import com.owlplug.plugin.model.IDirectory;
+import com.owlplug.plugin.model.IPlugin;
 import com.owlplug.plugin.model.Plugin;
 import com.owlplug.plugin.model.PluginComponent;
 import com.owlplug.plugin.model.PluginDirectory;
@@ -73,7 +74,7 @@ public class PluginTreeViewController extends BaseController {
         return null;
       }
       return (item) -> {
-        if (item instanceof Plugin plugin) {
+        if (item instanceof IPlugin plugin) {
           return plugin.getName().toLowerCase().contains(search.getValue().toLowerCase())
                   || (plugin.getCategory() != null && plugin.getCategory().toLowerCase().contains(
                       search.getValue().toLowerCase()));
@@ -89,7 +90,7 @@ public class PluginTreeViewController extends BaseController {
         return null;
       }
       return (item) -> {
-        if (item instanceof Plugin plugin) {
+        if (item instanceof IPlugin plugin) {
           return plugin.getName().toLowerCase().contains(search.getValue().toLowerCase())
                   || (plugin.getCategory() != null && plugin.getCategory().toLowerCase().contains(search.getValue().toLowerCase()));
         } else {

--- a/owlplug-client/src/main/java/com/owlplug/plugin/model/IPlugin.java
+++ b/owlplug-client/src/main/java/com/owlplug/plugin/model/IPlugin.java
@@ -1,0 +1,57 @@
+/* OwlPlug
+ * Copyright (C) 2021 Arthur <dropsnorz@gmail.com>
+ *
+ * This file is part of OwlPlug.
+ *
+ * OwlPlug is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 3
+ * as published by the Free Software Foundation.
+ *
+ * OwlPlug is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with OwlPlug.  If not, see <https://www.gnu.org/licenses/>.
+ */
+
+
+package com.owlplug.plugin.model;
+
+public interface IPlugin {
+
+  /**
+   * Retrieve the associated Plugin object from this Plugin object.
+   * In case of Component, it returns the parent plugin.
+   * In case of Plugin, it should return itself.
+   * @return plugin
+   */
+  Plugin asPlugin();
+
+  /**
+   * Get object identifier.
+   * The identifier is not guaranteed to be unique across Plugin and Component.
+   * @return id
+   */
+  Long getId();
+
+  String getName();
+
+  String getDescriptiveName();
+
+  String getVersion();
+
+  String getUid();
+
+  String getCategory();
+
+  String getManufacturerName();
+
+  String getIdentifier();
+
+  String getBundleId();
+
+  PluginType getType();
+
+}

--- a/owlplug-client/src/main/java/com/owlplug/plugin/model/Plugin.java
+++ b/owlplug-client/src/main/java/com/owlplug/plugin/model/Plugin.java
@@ -42,7 +42,7 @@ import org.hibernate.annotations.OnDeleteAction;
 @Inheritance
 @Table(indexes = { @Index(name = "IDX_PLUGIN_ID", columnList = "id"),
     @Index(name = "IDX_PLUGIN_NAME", columnList = "name") })
-public class Plugin {
+public class Plugin implements IPlugin {
 
   @Id
   @GeneratedValue(strategy = GenerationType.AUTO)
@@ -237,5 +237,10 @@ public class Plugin {
 
   public void setComponents(Set<PluginComponent> components) {
     this.components = components;
+  }
+
+  @Override
+  public Plugin asPlugin() {
+    return this;
   }
 }

--- a/owlplug-client/src/main/java/com/owlplug/plugin/model/PluginComponent.java
+++ b/owlplug-client/src/main/java/com/owlplug/plugin/model/PluginComponent.java
@@ -19,6 +19,7 @@
 package com.owlplug.plugin.model;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.EnumType;
 import jakarta.persistence.Enumerated;
@@ -31,7 +32,7 @@ import jakarta.persistence.Table;
 
 @Entity
 @Table(indexes = { @Index(name = "IDX_PLUGIN_COMPONENT_ID", columnList = "id") })
-public class PluginComponent {
+public class PluginComponent implements IPlugin {
 
   @Id
   @GeneratedValue(strategy = GenerationType.AUTO)
@@ -47,6 +48,7 @@ public class PluginComponent {
   protected String version;
   @Enumerated(EnumType.STRING)
   protected PluginType type;
+
 
   @ManyToOne
   @JsonIgnore
@@ -140,4 +142,8 @@ public class PluginComponent {
     this.plugin = plugin;
   }
 
+  @Override
+  public Plugin asPlugin() {
+    return this.plugin;
+  }
 }

--- a/owlplug-client/src/main/java/com/owlplug/plugin/model/PluginFootprint.java
+++ b/owlplug-client/src/main/java/com/owlplug/plugin/model/PluginFootprint.java
@@ -39,6 +39,8 @@ public class PluginFootprint {
   protected boolean nativeDiscoveryEnabled = true;
 
   protected String screenshotUrl;
+
+  private String lastScanStatus;
   
   public PluginFootprint() {
   }
@@ -73,6 +75,14 @@ public class PluginFootprint {
 
   public Long getId() {
     return id;
+  }
+
+  public String getLastScanStatus() {
+    return lastScanStatus;
+  }
+
+  public void setLastScanStatus(String lastScanStatus) {
+    this.lastScanStatus = lastScanStatus;
   }
 
 }

--- a/owlplug-client/src/main/java/com/owlplug/plugin/services/NativeHostService.java
+++ b/owlplug-client/src/main/java/com/owlplug/plugin/services/NativeHostService.java
@@ -23,6 +23,7 @@ import com.owlplug.core.services.BaseService;
 import com.owlplug.host.NativePlugin;
 import com.owlplug.host.loaders.DummyPluginLoader;
 import com.owlplug.host.loaders.EmbeddedScannerPluginLoader;
+import com.owlplug.host.loaders.NativeLoaderException;
 import com.owlplug.host.loaders.NativePluginLoader;
 import com.owlplug.host.loaders.jni.JNINativePluginLoader;
 import jakarta.annotation.PostConstruct;
@@ -52,6 +53,8 @@ public class NativeHostService extends BaseService {
       loader.init();
     }
     configureCurrentPluginLoader();
+    long timeoutSeconds = this.getPreferences().getLong(ApplicationDefaults.NATIVE_LOADER_TIMEOUT_KEY, 30L);
+    EmbeddedScannerPluginLoader.getInstance().setTimeout(timeoutSeconds * 1000);
   }
 
   private void configureCurrentPluginLoader() {
@@ -110,7 +113,11 @@ public class NativeHostService extends BaseService {
     this.currentPluginLoader = pluginLoader;
   }
 
-  public List<NativePlugin> loadPlugin(String path) {
+  public void setScannerTimeout(long timeoutSeconds) {
+    EmbeddedScannerPluginLoader.getInstance().setTimeout(timeoutSeconds * 1000);
+  }
+
+  public List<NativePlugin> loadPlugin(String path) throws NativeLoaderException {
     if (currentPluginLoader != null) {
       return currentPluginLoader.loadPlugin(path);
     } else {

--- a/owlplug-client/src/main/java/com/owlplug/plugin/tasks/PluginScanTask.java
+++ b/owlplug-client/src/main/java/com/owlplug/plugin/tasks/PluginScanTask.java
@@ -21,7 +21,9 @@ package com.owlplug.plugin.tasks;
 import com.owlplug.core.tasks.AbstractTask;
 import com.owlplug.core.tasks.TaskException;
 import com.owlplug.core.tasks.TaskResult;
+import com.owlplug.core.utils.StringUtils;
 import com.owlplug.host.NativePlugin;
+import com.owlplug.host.loaders.NativeLoaderException;
 import com.owlplug.plugin.model.Plugin;
 import com.owlplug.plugin.model.PluginComponent;
 import com.owlplug.plugin.model.PluginFootprint;
@@ -172,27 +174,35 @@ public class PluginScanTask extends AbstractTask {
 
         log.debug("Load plugin using native discovery: " + plugin.getPath());
         this.updateMessage("Exploring plugin " + plugin.getName());
-        List<NativePlugin> nativePlugins = nativeHostService.loadPlugin(plugin.getPath());
+        try {
+          List<NativePlugin> nativePlugins = nativeHostService.loadPlugin(plugin.getPath());
+          pluginFootprint.setLastScanStatus(null);
 
-        if (nativePlugins != null && !nativePlugins.isEmpty()) {
-          log.debug("Found {} components (nativePlugin) for plugin {}", nativePlugins.size(), plugin.getName());
+          if (!nativePlugins.isEmpty()) {
+            log.debug("Found {} components (nativePlugin) for plugin {}", nativePlugins.size(), plugin.getName());
 
-          plugin.setNativeCompatible(true);
+            plugin.setNativeCompatible(true);
 
-          for (NativePlugin nativePlugin : nativePlugins) {
-            PluginComponent component = createComponentFromNative(nativePlugin);
-            component.setPlugin(plugin);
-            plugin.getComponents().add(component);
-            log.debug("Created component {} for plugin {}", component.getName(), plugin.getName());
+            for (NativePlugin nativePlugin : nativePlugins) {
+              PluginComponent component = createComponentFromNative(nativePlugin);
+              component.setPlugin(plugin);
+              plugin.getComponents().add(component);
+              log.debug("Created component {} for plugin {}", component.getName(), plugin.getName());
+            }
+
+            // Hardcode plugin properties from the first component (nativePlugin) retrieved.
+            mapPluginPropertiesFromNative(plugin, nativePlugins.get(0));
           }
-
-          // Hardcode plugin properties from the first component (nativePlugin) retrieved.
-          mapPluginPropertiesFromNative(plugin, nativePlugins.get(0));
-
+        } catch (NativeLoaderException e) {
+          log.error("Native scan failed for plugin {}: {}", plugin.getName(), e.getMessage());
+          pluginFootprint.setLastScanStatus(StringUtils.truncate(
+              e.getMessage(), 240, "..."
+          ));
         }
       }
 
       plugin.setScanComplete(true);
+      pluginFootprintRepository.save(pluginFootprint);
       pluginRepository.save(plugin);
 
       this.commitProgress(80.0 / pluginFiles.size());

--- a/owlplug-client/src/main/resources/fxml/OptionsView.fxml
+++ b/owlplug-client/src/main/resources/fxml/OptionsView.fxml
@@ -29,12 +29,13 @@
                <VBox spacing="20.0">
                   <VBox fx:id="pluginPathContainer" spacing="10.0" />
                   <VBox spacing="4.0">
-                     <VBox.margin>
-                        <Insets bottom="16.0" top="10.0" />
-                     </VBox.margin>
                      <HBox spacing="10.0">
                         <CheckBox fx:id="pluginNativeCheckbox" text="Native plugin discovery using" />
                         <ComboBox fx:id="pluginNativeComboBox" prefHeight="25.0" HBox.hgrow="NEVER" />
+                     </HBox>
+                     <HBox alignment="CENTER_LEFT" spacing="10.0">
+                        <Label text="Native loader timeout (in seconds)" />
+                        <TextField fx:id="loaderTimeoutTextField" prefWidth="60.0" />
                      </HBox>
                      <Label styleClass="label-emphase" text="Allow deep plugin metadatas discovery using platform specific features" />
                   </VBox>

--- a/owlplug-client/src/main/resources/fxml/plugins/PluginInfoView.fxml
+++ b/owlplug-client/src/main/resources/fxml/plugins/PluginInfoView.fxml
@@ -137,5 +137,12 @@
             </HBox.margin>
          </ToggleSwitch>
       </HBox>
+      <HBox alignment="CENTER_LEFT">
+        <Label fx:id="lastScanErrorLabel" wrapText="true" >
+           <HBox.margin>
+                <Insets  top="5" bottom="5" left="5"/>
+           </HBox.margin>
+        </Label>
+      </HBox>
    </VBox>
 </AnchorPane>

--- a/owlplug-controls/pom.xml
+++ b/owlplug-controls/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>owlplug</artifactId>
         <groupId>com.owlplug</groupId>
-        <version>1.33.0</version>
+        <version>1.33.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/owlplug-host/pom.xml
+++ b/owlplug-host/pom.xml
@@ -7,7 +7,7 @@
 	<parent>
 		<groupId>com.owlplug</groupId>
 		<artifactId>owlplug</artifactId>
-		<version>1.33.0</version>
+		<version>1.33.1</version>
 	</parent>
 	<artifactId>owlplug-host</artifactId>
 	<name>owlplug-host</name>

--- a/owlplug-host/src/main/java/com/owlplug/host/io/CommandRunner.java
+++ b/owlplug-host/src/main/java/com/owlplug/host/io/CommandRunner.java
@@ -57,12 +57,10 @@ public class CommandRunner {
     Process process = pb.start();
 
     ExecutorService executor = Executors.newFixedThreadPool(1);
+    Future<String> stdoutFuture = executor.submit(new StreamReader(process.getInputStream()));
 
-    Callable<String> stdoutReader = new StreamReader(process.getInputStream());
-    Future<String> stdoutFuture = executor.submit(stdoutReader);
-
-    boolean finished;
     try {
+      boolean finished;
       if (timeoutActivated) {
         finished = process.waitFor(timeout, TimeUnit.MILLISECONDS);
       } else {
@@ -70,27 +68,21 @@ public class CommandRunner {
         finished = true;
       }
 
-    } catch (InterruptedException e) {
-      log.error("Interrupted while waiting for process");
-      process.destroy();
-      throw new IOException("Interrupted while waiting for process", e);
-    }
+      if (!finished) {
+        log.error("Forcibly destroying process after timeout {}ms exceeded.", timeout);
+        throw new IOException("Process timeout exceeded: " + timeout + "ms");
+      }
 
-    if (!finished) {
-      log.error("Forcibly destroying process after timeout {}ms exceeded.", timeout);
-      process.destroyForcibly();
-      throw new IOException("Process timeout exceeded: " + timeout + "ms");
-    }
-
-    try {
-      // Let 1 seconds for gracefully read and complete process
       String stdout = stdoutFuture.get(1, TimeUnit.SECONDS);
       return new CommandResult(process.exitValue(), stdout);
     } catch (InterruptedException e) {
-      throw new IOException("Interrupted while reading process output", e);
+      throw new IOException("Process execution interrupted", e);
     } catch (ExecutionException | TimeoutException e) {
       throw new IOException("Failed to read process output", e);
     } finally {
+      // destroyForcibly closes the process streams, which unblocks any readLine()
+      // call in the StreamReader thread — safe to call even if the process already exited
+      process.destroyForcibly();
       executor.shutdownNow();
     }
   }

--- a/owlplug-host/src/main/java/com/owlplug/host/loaders/DummyPluginLoader.java
+++ b/owlplug-host/src/main/java/com/owlplug/host/loaders/DummyPluginLoader.java
@@ -47,8 +47,8 @@ public class DummyPluginLoader implements NativePluginLoader {
   }
 
   @Override
-  public List<NativePlugin> loadPlugin(String path) {
-    return null;
+  public List<NativePlugin> loadPlugin(String path) throws NativeLoaderException {
+    return List.of();
   }
 
   @Override

--- a/owlplug-host/src/main/java/com/owlplug/host/loaders/EmbeddedScannerPluginLoader.java
+++ b/owlplug-host/src/main/java/com/owlplug/host/loaders/EmbeddedScannerPluginLoader.java
@@ -58,9 +58,11 @@ public class EmbeddedScannerPluginLoader implements NativePluginLoader {
   private static final String DEFAULT_SCANNER_ID =
       DEFAULT_SCANNER_NAME + "-" + DEFAULT_SCANNER_VERSION + "-" + DEFAULT_SCANNER_PLATFORM_TAG + DEFAULT_SCANNER_EXT;
 
+  private final String scannerDirectory;
+  private final String scannerId;
   private boolean available = false;
-  private String scannerDirectory;
-  private String scannerId;
+  // 10s default timeout for scanner execution
+  private long timeoutMillis = 10000;
 
   public static EmbeddedScannerPluginLoader getInstance() {
     if (INSTANCE == null) {
@@ -112,7 +114,7 @@ public class EmbeddedScannerPluginLoader implements NativePluginLoader {
   }
 
   @Override
-  public List<NativePlugin> loadPlugin(String path) {
+  public List<NativePlugin> loadPlugin(String path) throws NativeLoaderException {
 
     log.debug("Load plugin {}", path);
 
@@ -123,27 +125,22 @@ public class EmbeddedScannerPluginLoader implements NativePluginLoader {
     try {
       CommandRunner commandRunner = new CommandRunner();
       commandRunner.setTimeoutActivated(true);
-      commandRunner.setTimeout(10000); // 10 seconds timeout
-      CommandResult result = commandRunner.run(scannerDirectory + SEPARATOR +  scannerId, path);
+      commandRunner.setTimeout(timeoutMillis);
+      CommandResult result = commandRunner.run(scannerDirectory + SEPARATOR + scannerId, path);
       log.debug("Response received from scanner");
       log.debug(result.getOutput());
 
       if (result.getExitValue() >= 0) {
-
         log.debug("Extracting XML from content received by the scanner");
-        String output = result.getOutput();
-
-        return createPluginsFromCommandOutput(output);
-
+        return createPluginsFromCommandOutput(result.getOutput());
       } else {
-        log.debug("Invalid return code {} received from plugin scanner", result.getExitValue());
+        throw new NativeLoaderException("Scanner exited with code " + result.getExitValue());
       }
 
     } catch (IOException e) {
       log.error("Error executing plugin scanner {}", path, e);
+      throw new NativeLoaderException("Scanner execution failed: " + e.getMessage(), e);
     }
-
-    return null;
   }
 
   private List<NativePlugin> createPluginsFromCommandOutput(String output) {
@@ -221,6 +218,10 @@ public class EmbeddedScannerPluginLoader implements NativePluginLoader {
   @Override
   public String getId() {
     return "owlplug-scanner";
+  }
+
+  public void setTimeout(long timeoutMillis) {
+    this.timeoutMillis = timeoutMillis;
   }
 
   @Override

--- a/owlplug-host/src/main/java/com/owlplug/host/loaders/EmbeddedScannerPluginLoader.java
+++ b/owlplug-host/src/main/java/com/owlplug/host/loaders/EmbeddedScannerPluginLoader.java
@@ -130,7 +130,7 @@ public class EmbeddedScannerPluginLoader implements NativePluginLoader {
       log.debug("Response received from scanner");
       log.debug(result.getOutput());
 
-      if (result.getExitValue() >= 0) {
+      if (result.getExitValue() == 0) {
         log.debug("Extracting XML from content received by the scanner");
         return createPluginsFromCommandOutput(result.getOutput());
       } else {

--- a/owlplug-host/src/main/java/com/owlplug/host/loaders/NativeLoaderException.java
+++ b/owlplug-host/src/main/java/com/owlplug/host/loaders/NativeLoaderException.java
@@ -18,23 +18,14 @@
 
 package com.owlplug.host.loaders;
 
-import com.owlplug.host.NativePlugin;
-import java.util.List;
+public class NativeLoaderException extends Exception {
 
-public interface NativePluginLoader {
+  public NativeLoaderException(String message) {
+    super(message);
+  }
 
-  public void init();
-
-  public void open();
-
-  public List<NativePlugin> loadPlugin(String path) throws NativeLoaderException;
-
-  public void close();
-
-  public boolean isAvailable();
-
-  public String getName();
-
-  public String getId();
+  public NativeLoaderException(String message, Throwable cause) {
+    super(message, cause);
+  }
 
 }

--- a/owlplug-host/src/main/java/com/owlplug/host/loaders/jni/JNINativePluginLoader.java
+++ b/owlplug-host/src/main/java/com/owlplug/host/loaders/jni/JNINativePluginLoader.java
@@ -19,6 +19,7 @@
 package com.owlplug.host.loaders.jni;
 
 import com.owlplug.host.NativePlugin;
+import com.owlplug.host.loaders.NativeLoaderException;
 import com.owlplug.host.loaders.NativePluginLoader;
 import java.util.List;
 
@@ -50,8 +51,12 @@ public class JNINativePluginLoader implements NativePluginLoader {
   }
 
   @Override
-  public List<NativePlugin> loadPlugin(String path) {
-    return nativePluginMapper.mapPlugin(path);
+  public List<NativePlugin> loadPlugin(String path) throws NativeLoaderException {
+    List<NativePlugin> plugins = nativePluginMapper.mapPlugin(path);
+    if (plugins == null) {
+      throw new NativeLoaderException("Scan rejected this plugin, probably incompatible with current platform.");
+    }
+    return plugins;
   }
 
   @Override

--- a/owlplug-parsers/pom.xml
+++ b/owlplug-parsers/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>owlplug</artifactId>
         <groupId>com.owlplug</groupId>
-        <version>1.33.0</version>
+        <version>1.33.1</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 
 	<groupId>com.owlplug</groupId>
 	<artifactId>owlplug</artifactId>
-	<version>1.33.0</version>
+	<version>1.33.1</version>
 	<packaging>pom</packaging>
 
 


### PR DESCRIPTION
Resolves #477 

**Content**
* Native loader timeout can be configured from the Options pane
* Errors during plugin native scan are reported in the plugin view
* Fixed a thread leak issue preventing the app from exiting correctly after a scan
* Fixed plugin component filtering from the tree and flat list view
* Plugin components are now correctly displayed in the table view